### PR TITLE
Allow to debug automatically in PHPSTORM

### DIFF
--- a/config/php/xdebug.ini
+++ b/config/php/xdebug.ini
@@ -1,9 +1,10 @@
 zend_extension=xdebug.so
 xdebug.remote_connect_back = 1
 xdebug.default_enable = 1
-xdebug.remote_autostart = 0
+xdebug.remote_autostart = 1
 xdebug.remote_enable = 1
 xdebug.remote_port = 9000
 xdebug.remote_handler = dbgp
 xdebug.max_nesting_level = 500
+xdebug.idekey = PHPSTORM 
 xdebug.profiler_enable_trigger = 1


### PR DESCRIPTION
Changing remote_autostart to 1 and adding idekey with PHPSTORM allows to debug automatically without any kind of cookie.
Turn on the PhpStorm phone and F5.