### PR TITLE
Support to Multi-byte UTF8 in Drupal 7

### DIFF
--- a/config/mysql/my.cnf
+++ b/config/mysql/my.cnf
@@ -107,8 +107,9 @@ max_binlog_size         = 100M
 # ssl-ca=/etc/mysql/cacert.pem
 # ssl-cert=/etc/mysql/server-cert.pem
 # ssl-key=/etc/mysql/server-key.pem
-
-
+innodb_large_prefix=true
+innodb_file_format=barracuda
+innodb_file_per_table=true
 
 [mysqldump]
 quick


### PR DESCRIPTION
Sometimes, on big UNIQUE KEYs (bigger than 191 chars), an error will raise displaying 'Mysql::Error: Specified key was too long; max key length is 761 bytes: '
That's because of utf8 and utf8mb4 use more bytes to store the same information.

Drupal use many UNIQUE KEY that are defined as varchar(255).

That patch, suggested in https://www.drupal.org/node/2754539, gives support to Multi-byte UTF8 strings in Drupal 7.